### PR TITLE
Modified Makefile to ensure bibliography is included

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 main: honeypot.tex honeypot.bib ieeeaccess.cls Images
 	./pics.sh
 	pdflatex honeypot
+	bibtex honeypot
+	pdflatex honeypot
+	pdflatex honeypot
 
 MYFILE = honeypot.txt
 clean:


### PR DESCRIPTION
I cloned a clean version of your repository and tried to build. I noticed that the references aren't built by the new Makefile so I've modified it so that they are.